### PR TITLE
Update module and examples to run on elm 0.16.

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -1,7 +1,7 @@
 {
-    "version": "4.0.1",
+    "version": "1.0.0",
     "summary": "A library for general 3D rendering with WebGL",
-    "repository": "https://github.com/johnpmayer/elm-webgl.git",
+    "repository": "https://github.com/elm-community/elm-webgl.git",
     "license": "BSD3",
     "source-directories": [
         "src"
@@ -11,8 +11,7 @@
     ],
     "native-modules": true,
     "dependencies": {
-        "elm-lang/core": "2.0.0 <= v < 3.0.0",
-        "johnpmayer/elm-linear-algebra": "2.0.1 <= v < 3.0.0"
+        "elm-lang/core": "2.0.0 <= v < 4.0.0"
     },
-    "elm-version": "0.15.0 <= v < 0.16.0"
+    "elm-version": "0.16.0 <= v < 0.17.0"
 }

--- a/examples/crate.elm
+++ b/examples/crate.elm
@@ -49,7 +49,7 @@ rotatedFace (angleX,angleY) =
     each f (a,b,c) =
       (f a, f b, f c)
   in
-    List.map (each (\x -> {x | pos <- transform t x.pos })) face
+    List.map (each (\x -> {x | pos = transform t x.pos })) face
 
 
 face : List ({ pos:Vec3, coord:Vec3 }, { pos:Vec3, coord:Vec3 }, { pos:Vec3, coord:Vec3 })

--- a/examples/elm-package.json
+++ b/examples/elm-package.json
@@ -1,17 +1,17 @@
 {
     "version": "1.0.0",
     "summary": "Examples",
-    "repository": "https://github.com/USER/PROJECT.git",
+    "repository": "https://github.com/elm-community/elm-webgl.git",
     "license": "BSD3",
     "source-directories": [
         "."
 	, "../src"
+	, "../../elm-linear-algebra/src"
     ],
     "native-modules": true,
     "exposed-modules": [],
     "dependencies": {
-        "elm-lang/core": "2.1.0 <= v < 3.0.0",
-        "johnpmayer/elm-linear-algebra": "2.0.2 <= v < 3.0.0"
+        "elm-lang/core": "2.1.0 <= v < 4.0.0"
     },
-    "elm-version": "0.15.1 <= v < 0.16.0"
+    "elm-version": "0.16.0 <= v < 0.17.0"
 }

--- a/examples/first-person.elm
+++ b/examples/first-person.elm
@@ -57,7 +57,7 @@ walk directions person =
       vz = toFloat  directions.y
     in
       { person |
-          velocity <- vec3 vx (getY person.velocity) vz
+          velocity = vec3 vx (getY person.velocity) vz
       }
 
 
@@ -70,7 +70,7 @@ jump isJumping person =
       (vx,_,vz) = toTuple person.velocity
     in
       { person |
-          velocity <- vec3 vx 2 vz
+          velocity = vec3 vx 2 vz
       }
 
 
@@ -83,7 +83,7 @@ physics dt person =
     (x,y,z) = toTuple position
   in
     { person |
-        position <-
+        position =
             if y < eyeLevel then vec3 x eyeLevel z else position
     }
 
@@ -97,7 +97,7 @@ gravity dt person =
       v = toRecord person.velocity
     in
       { person |
-          velocity <- vec3 v.x (v.y - 2 * dt) v.z
+          velocity = vec3 v.x (v.y - 2 * dt) v.z
       }
 
 
@@ -195,7 +195,7 @@ rotatedFace (angleXZ,angleYZ) =
     t = x `mul` y
     each f (a,b,c) = (f a, f b, f c)
   in
-    List.map (each (\v -> {v | position <- transform t v.position })) face
+    List.map (each (\v -> {v | position = transform t v.position })) face
 
 
 face : List (Vertex, Vertex, Vertex)

--- a/examples/thwomp.elm
+++ b/examples/thwomp.elm
@@ -57,7 +57,7 @@ rotatedSquare (angleXZ,angleYZ) =
         t = x `mul` y
         each f (a,b,c) = (f a, f b, f c)
     in
-        List.map (each (\v -> {v | position <- transform t v.position })) square
+        List.map (each (\v -> {v | position = transform t v.position })) square
 
 
 square : List (Vertex, Vertex, Vertex)


### PR DESCRIPTION
Because the examples depend on a version of elm-linear-algebra for 0.16 and such is not
yet published, this depends on it existing at ../elm-linear-algebra.
