### PR TITLE
Add installation note for elm 0.16.

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,3 +145,16 @@ type of `vertexShader` says that we have two attributes named `position` and
 Elm's type checker can make sure you are using the shader in a meaningful way,
 avoiding a totally blank screen that can happen if your shader has an error in
 it.
+
+### Installing
+
+This library depends on
+[elm-linear-algebra](https://github.com/elm-community/elm-linear-algebra) which
+is not yet available via elm-package for elm version 0.16. So, to build
+elm-webgl you must first install the 0.16-compatible version of
+elm-linear-algebra alongside of elm-webgl. It goes something like this:
+
+    git clone git@github.com:elm-community/elm-linear-algebra.git
+    git clone git@github.com:elm-community/elm-webgl.git
+    cd elm-webgl/examples
+    elm reactor


### PR DESCRIPTION
Describes dependency on unpublished version of elm-linear-algebra.
