### PR TITLE
Updated examples to 0.17

### DIFF
--- a/examples/cube.elm
+++ b/examples/cube.elm
@@ -1,21 +1,20 @@
 import Color exposing (..)
-import Graphics.Element exposing (..)
+import Element
 import Math.Vector3 exposing (..)
 import Math.Matrix4 exposing (..)
-import Time exposing (..)
 import WebGL exposing (..)
+import Html.App as Html
+import AnimationFrame
 
 
--- SIGNALS
-
-main : Signal Element
+main : Program Never
 main =
-  Signal.map (webgl (400,400)) (Signal.map scene angle)
-
-
-angle : Signal Float
-angle =
-  Signal.foldp (\dt theta -> theta + dt / 5000) 0 (fps 25)
+  Html.program
+    { init = (0, Cmd.none)
+    , view = scene >> webgl (400, 400) >> Element.toHtml
+    , subscriptions = (\model -> AnimationFrame.diffs Basics.identity)
+    , update = (\dt theta -> (theta + dt / 5000, Cmd.none))
+    }
 
 
 -- MESHES - create a cube in which each vertex has a position and color

--- a/examples/elm-package.json
+++ b/examples/elm-package.json
@@ -11,8 +11,12 @@
     "native-modules": true,
     "dependencies": {
         "elm-community/elm-linear-algebra": "2.0.1 <= v <= 2.0.1",
+        "elm-lang/animation-frame": "1.0.0 <= v < 2.0.0",
         "elm-lang/core": "4.0.0 <= v <= 4.0.0",
         "elm-lang/html": "1.0.0 <= v < 2.0.0",
+        "elm-lang/keyboard": "1.0.0 <= v < 2.0.0",
+        "elm-lang/mouse": "1.0.0 <= v < 2.0.0",
+        "elm-lang/window": "1.0.0 <= v < 2.0.0",
         "evancz/elm-graphics": "1.0.0 <= v < 2.0.0"
     },
     "elm-version": "0.17.0 <= v < 0.18.0"

--- a/examples/mouse_bug.elm
+++ b/examples/mouse_bug.elm
@@ -1,12 +1,22 @@
 
+import Element
 import Mouse
-import Window
 import WebGL as GL
 import Math.Vector3 exposing (..)
 import Math.Vector2 exposing (..)
 import Math.Matrix4 as Mat4
+import Html.App as Html
+import Html exposing (Html)
 
-main = map view Mouse.position
+
+main : Program Never
+main =
+  Html.program
+    { init = ({x = 0, y = 0}, Cmd.none)
+    , view = view
+    , subscriptions = (\_ -> Mouse.moves identity)
+    , update = (\pos _ -> (pos, Cmd.none))
+    }
 
 
 type alias Vertex = { position : Vec2, color : Vec3 }
@@ -24,15 +34,16 @@ mesh = GL.Triangle <|
     ]
 
 
+ortho2D : Float -> Float -> Mat4.Mat4
 ortho2D w h = Mat4.makeOrtho2D 0 w h 0
 
 
-
-view : (Int,Int)  -> a
-view (w,h) =
+view : Mouse.Position -> Html (Mouse.Position)
+view {x, y} =
   let matrix = ortho2D 1 1
-  in GL.webgl (w,h)
+  in GL.webgl (x, y)
     [ GL.render vertexShader fragmentShader mesh { mat = matrix } ]
+    |> Element.toHtml
 
 
 -- Shaders

--- a/examples/triangle.elm
+++ b/examples/triangle.elm
@@ -1,11 +1,10 @@
-import Element exposing (..)
+import Element
 import Math.Vector3 exposing (..)
 import Math.Matrix4 exposing (..)
-import Time exposing (..)
 import WebGL exposing (..)
 import Html exposing (Html)
 import Html.App as Html
-
+import AnimationFrame
 
 -- Create a mesh with two triangles
 
@@ -21,15 +20,13 @@ mesh = Triangle
   ]
 
 
---type Msg = NewTime Float
--- Create the scene
-
+main : Program Never
 main =
   Html.program
-    { init = (5, Cmd.none)
+    { init = (0, Cmd.none)
     , view = view
-    , subscriptions = (\model -> Sub.batch [ Time.every (30 * Time.millisecond) Basics.identity ])
-    , update = (\x m -> (x, Cmd.none))
+    , subscriptions = (\model -> AnimationFrame.diffs Basics.identity)
+    , update = (\elapsed currentTime -> (elapsed + currentTime, Cmd.none))
     }
 
 
@@ -38,6 +35,7 @@ view t =
   webgl (400,400)
     [ render vertexShader fragmentShader mesh { perspective = perspective (t / 1000) } ]
     |> Element.toHtml
+
 
 perspective : Float -> Mat4
 perspective t =

--- a/src/Native/WebGL.js
+++ b/src/Native/WebGL.js
@@ -5,15 +5,11 @@ var _elm_community$elm_webgl$Native_WebGL = function() {
     // console.log(msg);
   }
 
-  var createNode = _evancz$elm_graphics$Native_Element.createNode;
-  var newElement = _evancz$elm_graphics$Native_Element.newElement;
-
   var List   =
     { map: _elm_lang$core$List$map
     , length: _elm_lang$core$List$length
     };
   var Utils  = _elm_lang$core$Native_Utils;
-  var Tuple2 = F2(function(a, b) { return {'ctor' : '_Tuple2', _0: a, _1: b} ;});
 
   function unsafeCoerceGLSL(src) {
     return { src : src };
@@ -48,7 +44,7 @@ var _elm_community$elm_webgl$Native_WebGL = function() {
 
   function textureSize(texture) {
 
-    return Tuple2(texture.img.width, texture.img.height);
+    return Utils.Tuple2(texture.img.width, texture.img.height);
 
   }
 
@@ -437,9 +433,9 @@ var _elm_community$elm_webgl$Native_WebGL = function() {
 
     function render(model) {
 
-      var div = createNode('div');
+      var div = _evancz$elm_graphics$Native_Element.createNode('div');
       div.style.overflow = 'hidden';
-      var canvas = createNode('canvas');
+      var canvas = _evancz$elm_graphics$Native_Element.createNode('canvas');
       var gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');
 
       if (gl) {
@@ -503,7 +499,7 @@ var _elm_community$elm_webgl$Native_WebGL = function() {
       }
     };
 
-    return A3(newElement, w, h, elem);
+    return A3(_evancz$elm_graphics$Native_Element.newElement, w, h, elem);
 
   }
 


### PR DESCRIPTION
I quickly ported all examples to 0.17. 

There are a few changes to the native code because when I tried to use the library in [elm-street-404](https://github.com/zalando/elm-street-404),  `_evancz$elm_graphics$Native_Element` was defined later than webgl module and resulted in `undefined`. 

Also, an ad hoc implementation of `Tuple2` to get texture size didn't work so I used the one from Utils.
