### PR TITLE
Implement native toHtml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 elm-stuff
 index.html
+.DS_Store

--- a/elm-package.json
+++ b/elm-package.json
@@ -12,7 +12,7 @@
     "native-modules": true,
     "dependencies": {
         "elm-lang/core": "4.0.0 <= v <= 4.0.0",
-        "evancz/elm-graphics": "1.0.0 <= v < 2.0.0"
+        "elm-lang/html": "1.0.0 <= v < 2.0.0"
     },
     "elm-version": "0.17.0 <= v < 0.18.0"
 }

--- a/examples/crate.elm
+++ b/examples/crate.elm
@@ -1,4 +1,3 @@
-import Element
 import Math.Vector2 exposing (Vec2)
 import Math.Vector3 exposing (..)
 import Math.Matrix4 exposing (..)
@@ -8,6 +7,7 @@ import WebGL exposing (..)
 import Html exposing (Html)
 import Html.App as Html
 import AnimationFrame
+import Html.Attributes exposing (width, height)
 
 
 type alias Model =
@@ -108,14 +108,14 @@ camera =
 
 view : Model -> Html Action
 view {texture, theta} =
+
   (case texture of
     Nothing ->
         []
     Just tex ->
         [render vertexShader fragmentShader crate { crate = tex, perspective = perspective theta }]
   )
-  |> webgl (400, 400)
-  |> Element.toHtml
+  |> WebGL.toHtml [width 400, height 400]
 
 
 -- SHADERS

--- a/examples/cube.elm
+++ b/examples/cube.elm
@@ -1,17 +1,17 @@
 import Color exposing (..)
-import Element
 import Math.Vector3 exposing (..)
 import Math.Matrix4 exposing (..)
 import WebGL exposing (..)
 import Html.App as Html
 import AnimationFrame
+import Html.Attributes exposing (width, height)
 
 
 main : Program Never
 main =
   Html.program
     { init = (0, Cmd.none)
-    , view = scene >> webgl (400, 400) >> Element.toHtml
+    , view = scene >> WebGL.toHtml [width 400, height 400]
     , subscriptions = (\model -> AnimationFrame.diffs Basics.identity)
     , update = (\dt theta -> (theta + dt / 5000, Cmd.none))
     }

--- a/examples/elm-package.json
+++ b/examples/elm-package.json
@@ -16,8 +16,7 @@
         "elm-lang/html": "1.0.0 <= v < 2.0.0",
         "elm-lang/keyboard": "1.0.0 <= v < 2.0.0",
         "elm-lang/mouse": "1.0.0 <= v < 2.0.0",
-        "elm-lang/window": "1.0.0 <= v < 2.0.0",
-        "evancz/elm-graphics": "1.0.0 <= v < 2.0.0"
+        "elm-lang/window": "1.0.0 <= v < 2.0.0"
     },
     "elm-version": "0.17.0 <= v < 0.18.0"
 }

--- a/examples/first-person.elm
+++ b/examples/first-person.elm
@@ -1,17 +1,16 @@
 -- Try adding the ability to crouch or to land on top of the crate.
 
-import Element exposing (..)
 import Keyboard
 import Math.Vector2 exposing (Vec2)
 import Math.Vector3 exposing (..)
 import Math.Vector3 as V3
 import Math.Matrix4 exposing (..)
 import Task exposing (Task)
-import Text
 import Time exposing (..)
 import WebGL exposing (..)
-import Html exposing (Html)
+import Html exposing (Html, text, div)
 import Html.App as Html
+import Html.Attributes exposing (width, height, style)
 import AnimationFrame
 import Window
 
@@ -222,23 +221,34 @@ view {size, person, texture} =
     perspectiveMatrix = perspective (size.width, size.height) person
     entities = world texture perspectiveMatrix
   in
-    layers
-      [ webgl (size.width, size.height) entities
-      , container size.width 100 position message
+    div
+      [ style
+          [ ("width", toString size.width ++ "px")
+          , ("height", toString size.height ++ "px")
+          , ("position", "relative")
+          ]
       ]
-    |> Element.toHtml
+      [ WebGL.toHtml
+          [width size.width, height size.height, style [("display", "block")]]
+          entities
+      , div
+          [ style
+              [ ("position", "absolute")
+              , ("font-family", "monospace")
+              , ("text-align", "center")
+              , ("left", "20px")
+              , ("right", "20px")
+              , ("top", "20px")
+              ]
+          ]
+          [text message]
+      ]
 
 
-position : Position
-position =
-  midLeftAt (absolute 40) (relative 0.5)
-
-
-message : Element
+message : String
 message =
-  leftAligned <| Text.monospace <| Text.fromString <|
-      "Walk around with a first person perspective.\n"
-      ++ "Arrows keys to move, space bar to jump."
+  "Walk around with a first person perspective.\n"
+  ++ "Arrows keys to move, space bar to jump."
 
 
 -- Define the mesh for a crate

--- a/examples/mouse_bug.elm
+++ b/examples/mouse_bug.elm
@@ -1,5 +1,3 @@
-
-import Element
 import Mouse
 import WebGL as GL
 import Math.Vector3 exposing (..)
@@ -7,6 +5,7 @@ import Math.Vector2 exposing (..)
 import Math.Matrix4 as Mat4
 import Html.App as Html
 import Html exposing (Html)
+import Html.Attributes exposing (width, height)
 
 
 main : Program Never
@@ -40,10 +39,9 @@ ortho2D w h = Mat4.makeOrtho2D 0 w h 0
 
 view : Mouse.Position -> Html (Mouse.Position)
 view {x, y} =
-  let matrix = ortho2D 1 1
-  in GL.webgl (x, y)
-    [ GL.render vertexShader fragmentShader mesh { mat = matrix } ]
-    |> Element.toHtml
+  GL.toHtml
+    [width x, height y]
+    [ GL.render vertexShader fragmentShader mesh { mat = ortho2D 1 1 } ]
 
 
 -- Shaders

--- a/examples/thwomp.elm
+++ b/examples/thwomp.elm
@@ -1,7 +1,6 @@
 -- Thanks to The PaperNES Guy for the texture:
 -- http://the-papernes-guy.deviantart.com/art/Thwomps-Thwomps-Thwomps-186879685
 
-import Element
 import Math.Vector2 exposing (Vec2)
 import Math.Vector3 as V3 exposing (..)
 import Math.Matrix4 exposing (..)
@@ -11,6 +10,7 @@ import WebGL exposing (..)
 import Window
 import Html.App as Html
 import Html exposing (Html)
+import Html.Attributes exposing (width, height)
 
 
 type alias Model =
@@ -142,14 +142,13 @@ view : List (Vertex, Vertex, Vertex)
 view mesh1 mesh2 ({textures, size} as model) =
   let
     perspectiveMatrix = perspective model
-    dimensions = (size.width, size.height)
     (texture1, texture2) = textures
   in
-    webgl dimensions
+    WebGL.toHtml
+      [ width size.width, height size.height ]
       ( toEntity mesh1 texture1 perspectiveMatrix ++
         toEntity mesh2 texture2 perspectiveMatrix
       )
-    |> Element.toHtml
 
 
 toEntity : List (Vertex, Vertex, Vertex) -> Maybe Texture -> Mat4 -> List Renderable

--- a/examples/triangle.elm
+++ b/examples/triangle.elm
@@ -1,9 +1,9 @@
-import Element
 import Math.Vector3 exposing (..)
 import Math.Matrix4 exposing (..)
 import WebGL exposing (..)
 import Html exposing (Html)
 import Html.App as Html
+import Html.Attributes exposing (width, height)
 import AnimationFrame
 
 -- Create a mesh with two triangles
@@ -32,9 +32,9 @@ main =
 
 view : Float -> Html msg
 view t =
-  webgl (400,400)
+  WebGL.toHtml
+    [ width 400, height 400 ]
     [ render vertexShader fragmentShader mesh { perspective = perspective (t / 1000) } ]
-    |> Element.toHtml
 
 
 perspective : Float -> Mat4

--- a/src/WebGL.elm
+++ b/src/WebGL.elm
@@ -1,4 +1,4 @@
-module WebGL exposing (..) -- where
+module WebGL exposing (..)
 
 {-| The WebGL API is for high performance rendering. Definitely read about
 [how WebGL works](https://github.com/johnpmayer/elm-webgl/blob/master/README.md)
@@ -11,8 +11,8 @@ documentation provided here.
 # Entities
 @docs render, renderWithConfig
 
-# WebGL Element
-@docs webgl, webglWithConfig, defaultConfiguration
+# WebGL Html
+@docs toHtml, toHtmlWith, defaultConfiguration
 
 # WebGL API Calls
 @docs FunctionCall
@@ -31,7 +31,7 @@ documentation provided here.
 
 -}
 
-import Element exposing (Element)
+import Html exposing (Html, Attribute)
 import Task exposing (Task)
 import List
 import Native.WebGL
@@ -145,22 +145,21 @@ defaultConfiguration =
   ]
 
 
-{-| Same as webglWithConfig but with default configurations,
+{-| Same as toHtmlWith but with default configurations,
 implicitly configured for you. See `defaultConfiguration` for more information.
 -}
-webgl : (Int,Int) -> List Renderable -> Element
-webgl =
-  webglWithConfig defaultConfiguration
+toHtml : List (Attribute msg) -> List Renderable -> Html msg
+toHtml =
+  toHtmlWith defaultConfiguration
 
 
 {-| Render a WebGL scene with the given dimensions and entities. Shaders and
 meshes are cached so that they do not get resent to the GPU, so it should be
 relatively cheap to create new entities out of existing values.
 -}
-webglWithConfig : List FunctionCall -> (Int,Int) -> List Renderable -> Element
-webglWithConfig functionCalls dimensions entities =
-  computeAPICalls functionCalls
-  |> Native.WebGL.webgl dimensions entities
+toHtmlWith : List FunctionCall -> List (Attribute msg) -> List Renderable -> Html msg
+toHtmlWith functionCalls =
+  Native.WebGL.toHtml (computeAPICalls functionCalls)
 
 
 {-| -}


### PR DESCRIPTION
Quickly updated the native module to depend only on `elm-lang/html` and made all examples work.

I also tried it with [elm-street-404](https://github.com/zalando/elm-street-404) and it worked fine. 

Please review carefully. 

UPDATE: using it for [elm-mogee](https://github.com/w0rm/elm-mogee) now.
