### PR TITLE
Cache getActiveUniform calls

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.0.0",
+    "version": "3.0.1",
     "summary": "A library for general 3D rendering with WebGL",
     "repository": "https://github.com/elm-community/elm-webgl.git",
     "license": "BSD3",
@@ -11,7 +11,7 @@
     ],
     "native-modules": true,
     "dependencies": {
-        "elm-lang/core": "4.0.0 <= v <= 4.0.0",
+        "elm-lang/core": "4.0.0 <= v < 5.0.0",
         "elm-lang/html": "1.0.0 <= v < 2.0.0"
     },
     "elm-version": "0.17.0 <= v < 0.18.0"

--- a/src/Native/WebGL.js
+++ b/src/Native/WebGL.js
@@ -226,6 +226,10 @@ var _elm_community$elm_webgl$Native_WebGL = function() {
 
   }
 
+  function getProgID (vertID, fragID) {
+    return vertID + '#' + fragID;
+  }
+
   function drawGL(domNode, data) {
 
     var model = data.model;
@@ -241,9 +245,10 @@ var _elm_community$elm_webgl$Native_WebGL = function() {
       if(List.length(render.buffer._0) === 0)
           return;
 
+      var progid
       var program;
       if (render.vert.id && render.frag.id) {
-        var progid = render.vert.id + '#' + render.frag.id;
+        progid = getProgID(render.vert.id, render.frag.id);
         program = model.cache.programs[progid];
       }
 
@@ -274,14 +279,19 @@ var _elm_community$elm_webgl$Native_WebGL = function() {
         }
 
         program = do_link(gl, vshader, fshader);
-        var progid = render.vert.id + '#' + render.frag.id;
+        progid = getProgID(render.vert.id, render.frag.id);
         model.cache.programs[progid] = program;
 
       }
 
       gl.useProgram(program);
 
-      var setters = createUniformSetters(gl, model, program);
+      progid = progid || getProgID(render.vert.id, render.frag.id);
+      var setters = model.cache.uniformSetters[progid];
+      if (!setters) {
+        setters = createUniformSetters(gl, model, program);
+        model.cache.uniformSetters[progid] = setters;
+      }
 
       setUniforms(setters, render.uniforms);
 
@@ -507,6 +517,7 @@ var _elm_community$elm_webgl$Native_WebGL = function() {
     model.cache.gl = gl;
     model.cache.shaders = [];
     model.cache.programs = {};
+    model.cache.uniformSetters = {};
     model.cache.buffers = [];
     model.cache.textures = [];
 


### PR DESCRIPTION
`gl.getActiveUniform` and `gl.getUniformLocation` do not need to be called every frame and can sometimes be very slow, (not sure if it's just my integrated graphics card or something.)

![getactiveuniformisslowsometimes](https://cloud.githubusercontent.com/assets/2133026/15791320/e92c2188-2993-11e6-8a56-183d117f9d74.png)
![getuniformlocationisslowsometimes](https://cloud.githubusercontent.com/assets/2133026/15791321/e930ccf6-2993-11e6-82d2-0c097869d965.png)

This pull request caches the result of these calls in a manner similar to the way the author of the [webgl fundamentals](http://webglfundamentals.org/webgl/lessons/webgl-less-code-more-fun.html) tutorial's [utility library](https://github.com/greggman/webgl-fundamentals/blob/master/webgl/resources/webgl-utils.js#L257) does.
