### PR TITLE
Fixed stencil operation function calls

### DIFF
--- a/src/Native/WebGL.js
+++ b/src/Native/WebGL.js
@@ -473,13 +473,13 @@ var _elm_community$elm_webgl$Native_WebGL = function() {
 
   function stencilOperation(fail, zfail, zpass) {
     return function(gl) {
-      gl.stencilOperation(gl[fail], gl[zfail], gl[zpass]);
+      gl.stencilOp(gl[fail], gl[zfail], gl[zpass]);
     }
   }
 
   function stencilOperationSeparate(face, fail, zfail, zpass) {
     return function(gl) {
-      gl.stencilOperationSeparate(gl[face], gl[fail], gl[zfail], gl[zpass]);
+      gl.stencilOpSeparate(gl[face], gl[fail], gl[zfail], gl[zpass]);
     }
   }
 


### PR DESCRIPTION
It seems that the native module was calling the wrong WebGL functions for both stencil `FunctionCall`s, resulting in an undefined is not a function error.
