### PR TITLE
Enable CORS request on an image

### DIFF
--- a/src/Native/WebGL.js
+++ b/src/Native/WebGL.js
@@ -29,6 +29,7 @@ var _elm_community$elm_webgl$Native_WebGL = function() {
       img.onerror = function(e) {
         return callback(_elm_lang$core$Native_Scheduler.fail({ ctor: 'Error' }));
       };
+      img.crossOrigin = 'Anonymous';
       img.src = source;
     });
   }
@@ -42,6 +43,7 @@ var _elm_community$elm_webgl$Native_WebGL = function() {
       img.onerror = function(e) {
         return callback(_elm_lang$core$Native_Scheduler.fail({ ctor: 'Error' }));
       };
+      img.crossOrigin = 'Anonymous';
       img.src = source;
     });
   }


### PR DESCRIPTION
In order to load textures from a different domain, `img.crossOrigin` attribute has to be set.

FYI https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-crossorigin
