### PR TITLE
Added useful missing function calls

### DIFF
--- a/src/Native/WebGL.js
+++ b/src/Native/WebGL.js
@@ -242,7 +242,7 @@ var _elm_community$elm_webgl$Native_WebGL = function() {
     if (!gl) return domNode;
 
     gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
-    gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+    gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT | gl.STENCIL_BUFFER_BIT);
     LOG("Drawing");
 
     function drawEntity(render) {
@@ -453,6 +453,10 @@ var _elm_community$elm_webgl$Native_WebGL = function() {
     return function(gl) { gl.depthFunc(gl[mode]); };
   }
 
+  function depthMask(mask) {
+    return function(gl) { gl.depthMask(mask); };
+  }
+
   function sampleCoverage(value, invert) {
     return function(gl) {
       gl.sampleCoverage(value, invert);
@@ -483,6 +487,18 @@ var _elm_community$elm_webgl$Native_WebGL = function() {
     }
   }
 
+  function stencilMask(mask) {
+    return function(gl) { gl.stencilMask(mask); };
+  }
+
+  function colorMask(r, g, b, a) {
+    return function(gl) { gl.colorMask(r, g, b, a); };
+  }
+
+  function scissor(x, y, w, h) {
+    return function(gl) { gl.scissor(x, y, w, h); };
+  }
+
 
   // VIRTUAL-DOM WIDGETS
 
@@ -506,7 +522,8 @@ var _elm_community$elm_webgl$Native_WebGL = function() {
 
     LOG("Render canvas");
 	  var canvas = document.createElement('canvas');
-    var gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');
+      var attributes = {stencil: true}
+      var gl = canvas.getContext('webgl', attributes) || canvas.getContext('experimental-webgl', attributes);
 
     if (gl) {
       A2(List.map, function(functionCall){
@@ -558,11 +575,15 @@ var _elm_community$elm_webgl$Native_WebGL = function() {
     blendEquationSeparate:F2(blendEquationSeparate),
     blendFunc:F2(blendFunc),
     depthFunc:depthFunc,
+    depthMask:depthMask,
     sampleCoverage:F2(sampleCoverage),
     stencilFunc:F3(stencilFunc),
     stencilFuncSeparate:F4(stencilFuncSeparate),
     stencilOperation:F3(stencilOperation),
     stencilOperationSeparate:F4(stencilOperationSeparate),
+    stencilMask:stencilMask,
+    colorMask:F4(colorMask),
+    scissor:F4(scissor),
     loadTextureRaw:F2(loadTextureRaw),
   };
 

--- a/src/Native/WebGL.js
+++ b/src/Native/WebGL.js
@@ -548,6 +548,7 @@ var _elm_community$elm_webgl$Native_WebGL = function () {
   function renderCanvas(model) {
 
     LOG('Render canvas');
+    var canvas = document.createElement('canvas');
     var attributes = {stencil: true}
     var gl = canvas.getContext('webgl', attributes) || canvas.getContext('experimental-webgl', attributes);
 

--- a/src/Native/WebGL.js
+++ b/src/Native/WebGL.js
@@ -265,7 +265,7 @@ var _elm_community$elm_webgl$Native_WebGL = function () {
 
     gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
     gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT | gl.STENCIL_BUFFER_BIT);
-    LOG("Drawing");
+    LOG('Drawing');
 
     function drawEntity(render) {
       if (_elm_lang$core$List$length(render.buffer._0) === 0) {

--- a/src/WebGL.elm
+++ b/src/WebGL.elm
@@ -203,6 +203,9 @@ computeAPICall function =
       computeCompareModeString mode
       |> Native.WebGL.depthFunc
 
+    DepthMask mask ->
+      Native.WebGL.depthMask mask
+
     SampleCoverageFunc (value, invert) ->
       Native.WebGL.sampleCoverage value invert
 
@@ -227,6 +230,15 @@ computeAPICall function =
           zfail = computeZModeString zfail'
           zpass = computeZModeString zpass'
       in Native.WebGL.stencilOperationSeparate face fail zfail zpass
+
+    StencilMask mask ->
+      Native.WebGL.stencilMask mask
+
+    ColorMask (r, g, b, a) ->
+      Native.WebGL.colorMask r g b a
+
+    Scissor (x, y, w, h) ->
+      Native.WebGL.scissor x y w h
 
 
 {-| The `FunctionCall` provides a typesafe way to call
@@ -261,6 +273,11 @@ and alpha source blending factors are computed
 and alpha destination blending factors are computed
 + `SrcAlphaSaturate` should only be used for the srcFactor);
 + Both values may not reference a `ConstantColor` value;
+
+`DepthMask(mask: Int)`
++ set the mask for the depth buffer. Any value drawn to the
++ depth buffer will be ANDed with the mask. Usually used to
++ turn drawing to the depth buffer on or off.
 
 `SampleCoverageFunc(value: Float, invert: Bool)`
 + specify multisample coverage parameters
@@ -299,6 +316,21 @@ The initial value is `Keep`
 + set front and/or back stencil test actions
 + `face`: Specifies whether front and/or back stencil state is updated.
 + See the description of `StencilOperation` for info about the other parameters.
+
+`StencilMask(mask: Int)`
++ set the stencil mask. This value is ANDed with anything drawn to the
++ stencil buffer. Usually used to turn writing to the stencil buffer
++ on or off.
+
+`ColorMask(r: Int, g: Int, b: Int, a: Int)`
++ set mask to be applied to anything drawn to the color buffer.
++ Values drawn to each channel will be ANDed with their
++ color mask respectively.
+
+`Scissor(x: Int, y: Int, width: Int, height: Int)`
++ set the scissor box, which limits the drawing of fragments to the
++ screen to a specified rectangle.
+
 -}
 type FunctionCall
   = Enable Capability
@@ -308,11 +340,15 @@ type FunctionCall
   | BlendEquationSeparate (BlendMode, BlendMode)
   | BlendFunc (BlendOperation, BlendOperation)
   | DepthFunc CompareMode
+  | DepthMask Int
   | SampleCoverageFunc (Float, Bool)
   | StencilFunc (CompareMode, Int, Int)
   | StencilFuncSeparate (FaceMode, CompareMode, Int, Int)
   | StencilOperation (ZMode, ZMode, ZMode)
   | StencilOperationSeparate (FaceMode, ZMode, ZMode, ZMode)
+  | StencilMask Int
+  | ColorMask (Int, Int, Int, Int)
+  | Scissor (Int, Int, Int, Int)
 
 
 {-| -}


### PR DESCRIPTION
I wanted to get y'all's eyes on this.

I implemented these function calls in my fork so I could do some of the things I wanted to do.
Went ahead and documented them in case y'all want to merge for the next version bump.

There's also the matter of the missing context attributes for the stencil buffer,
 i.e. : `canvas.getContext('webgl', {stencil: true})`.
This is a little more important because none of the stencil function calls will work with out it.
I can submit that part as separate PR if that would be preferred.
