### PR TITLE
Added gl.BOOL to createUniformSetters

### DIFF
--- a/src/Native/WebGL.js
+++ b/src/Native/WebGL.js
@@ -413,6 +413,10 @@ var _elm_community$elm_webgl$Native_WebGL = function () {
             gl.bindTexture(gl.TEXTURE_2D, tex);
             gl.uniform1i(uniformLocation, currentTexture);
           };
+        case gl.BOOL:
+          return function (value) {
+            gl.uniform1i(uniformLocation, value);
+          };
         default:
           LOG('Unsupported uniform type: ' + uniform.type);
           return function () {};


### PR DESCRIPTION
I am using `gl.uniform1i` as gl type based on https://github.com/gpjt/webgl-lessons/blob/master/lesson07/index.html#L435 (I am replicating the NeHe lessons in elm-webgl)
