### PR TITLE
Ability to use IndexTriangles

### DIFF
--- a/src/Native/WebGL.js
+++ b/src/Native/WebGL.js
@@ -205,7 +205,7 @@ var _elm_community$elm_webgl$Native_WebGL = function () {
     A2(_elm_lang$core$List$map, function (elem) {
       dataFill(array, attributeInfo.size, data_idx, elem, attribute.name);
       data_idx += attributeInfo.size * elem_length;
-    }, bufferElems);
+    }, _elm_lang$core$List$reverse(bufferElems));
 
     var buffer = gl.createBuffer();
     LOG('Created attribute buffer ' + attribute.name);

--- a/src/WebGL.elm
+++ b/src/WebGL.elm
@@ -45,6 +45,8 @@ to form any shape. Each corner of a triangle is called a *vertex* and contains a
 bunch of *attributes* that describe that particular corner. These attributes can
 be things like position and color.
 
+IndexedTriangles is a special mode in which you provide a list of attributes that describe the vertexes and and a list of indices, that are grouped in groups of three that refer to the vertexes that form each triangle.
+
 So when you create a `Triangle` you are really providing three sets of attributes
 that describe the corners of a triangle.
 
@@ -59,6 +61,7 @@ type Drawable attributes
   | Points (List attributes)
   | TriangleFan (List attributes)
   | TriangleStrip (List attributes)
+  | IndexedTriangles (List attributes, List Int)
 
 {-| Shader is a phantom data type. Don't instantiate it yourself. See below.
 -}


### PR DESCRIPTION
This provides the ability to specify indices. There is a nice explanation of this technique here http://www.opengl-tutorial.org/intermediate-tutorials/tutorial-9-vbo-indexing/

Here is a gist that uses this feature: https://gist.github.com/nacmartin/fb79c2a0a0b26d9bd2c233f8f2da7564 

Note that this is a change in the API. It doesn't break compatibility, as it only provides a new type for a union type, but I will understand if it is not merged.

This PR addresses #37
